### PR TITLE
add HMAC middleware

### DIFF
--- a/middleware/deferwriter.go
+++ b/middleware/deferwriter.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+)
+
+type DeferWriter struct {
+	http.ResponseWriter
+	buf *bytes.Buffer
+}
+
+func NewDeferWriter(w http.ResponseWriter) *DeferWriter {
+	return &DeferWriter{
+		ResponseWriter: w,
+		buf:            new(bytes.Buffer),
+	}
+}
+
+func (w *DeferWriter) Bytes() []byte {
+	return w.buf.Bytes()
+}
+
+func (w *DeferWriter) Write(b []byte) (int, error) {
+	return w.buf.Write(b)
+}
+
+func (w *DeferWriter) WriteAll() {
+	w.ResponseWriter.Write(w.buf.Bytes())
+}

--- a/middleware/hmac.go
+++ b/middleware/hmac.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/rayark/zin"
+)
+
+func NewHMACAuthenticator(headerKey, secret string) zin.Middleware {
+	return func(h httprouter.Handle) httprouter.Handle {
+		return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+			deferWriter := NewDeferWriter(w)
+			defer deferWriter.WriteAll()
+
+			h(deferWriter, r, p)
+			hmac := computeHMAC256(deferWriter.Bytes(), secret)
+			deferWriter.Header().Set(headerKey, hmac)
+		}
+	}
+}
+
+func computeHMAC256(msg []byte, secret string) string {
+	key, err := base64.StdEncoding.DecodeString(secret)
+	if err != nil {
+		panic(err)
+	}
+	h := hmac.New(sha256.New, key)
+	h.Write(msg)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}

--- a/middleware/hmac.go
+++ b/middleware/hmac.go
@@ -10,24 +10,25 @@ import (
 	"github.com/rayark/zin"
 )
 
+// NewHMACAuthenticator returns a wrapper middleware to add with
 func NewHMACAuthenticator(headerKey, secret string) zin.Middleware {
+	key, err := base64.StdEncoding.DecodeString(secret)
+	if err != nil {
+		return nil
+	}
 	return func(h httprouter.Handle) httprouter.Handle {
 		return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 			deferWriter := NewDeferWriter(w)
 			defer deferWriter.WriteAll()
 
 			h(deferWriter, r, p)
-			hmac := computeHMAC256(deferWriter.Bytes(), secret)
+			hmac := computeHMAC256(deferWriter.Bytes(), key)
 			deferWriter.Header().Set(headerKey, hmac)
 		}
 	}
 }
 
-func computeHMAC256(msg []byte, secret string) string {
-	key, err := base64.StdEncoding.DecodeString(secret)
-	if err != nil {
-		panic(err)
-	}
+func computeHMAC256(msg, key []byte) string {
 	h := hmac.New(sha256.New, key)
 	h.Write(msg)
 	return base64.StdEncoding.EncodeToString(h.Sum(nil))

--- a/middleware/hmac_test.go
+++ b/middleware/hmac_test.go
@@ -1,0 +1,52 @@
+package middleware
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/rayark/zin"
+)
+
+func TestHMACAuthenticator(t *testing.T) {
+	path := "/hmac"
+
+	req, err := http.NewRequest("GET", path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hmacHeaderKey := "HMAC-Authenticate-Hash"
+	secretInBytes := []byte("ThisIsSecret")
+	secretInBase64 := base64.StdEncoding.EncodeToString(secretInBytes)
+	message := []byte("this is http body content")
+	hmac := computeHMAC256(message, secretInBase64)
+
+	hmacWrapper := NewHMACAuthenticator(hmacHeaderKey, secretInBase64)
+	router := httprouter.New()
+	grp := zin.NewGroup("/", hmacWrapper)
+	grp.R(router.GET, path, func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		w.Header().Set("Content-Language", "klingon")
+		w.Write(message)
+	})
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	// check if regular header value consistent or not
+	if rec.HeaderMap.Get("Content-Language") != "klingon" {
+		t.Fatalf("standard header inconsistent")
+	}
+
+	// check if "hmac" header value identical to the expected one
+	if rec.HeaderMap.Get(hmacHeaderKey) != hmac {
+		t.Fatalf("appended header inconsistent")
+	}
+
+	// check if response body consistent or not
+	if string(rec.Body.Bytes()) != string(message) {
+		t.Fatalf("content body inconsistent")
+	}
+}

--- a/middleware/hmac_test.go
+++ b/middleware/hmac_test.go
@@ -22,7 +22,7 @@ func TestHMACAuthenticator(t *testing.T) {
 	secretInBytes := []byte("ThisIsSecret")
 	secretInBase64 := base64.StdEncoding.EncodeToString(secretInBytes)
 	message := []byte("this is http body content")
-	hmac := computeHMAC256(message, secretInBase64)
+	hmac := computeHMAC256(message, secretInBytes)
 
 	hmacWrapper := NewHMACAuthenticator(hmacHeaderKey, secretInBase64)
 	router := httprouter.New()

--- a/middleware/hmac_test.go
+++ b/middleware/hmac_test.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"encoding/base64"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,30 +10,48 @@ import (
 	"github.com/rayark/zin"
 )
 
-func TestHMACAuthenticator(t *testing.T) {
+const (
+	hmacHeaderKey   = "HMAC-Signature-Hash"
+	nounceHeaderKey = "Nounce-For-HMAC"
+	nounceString    = "this is nounce"
+	secretString    = "ThisIsSecret"
+	bodyContent     = "this is http body content"
+)
+
+func middlewareHMACTest(t *testing.T, reqHeaders map[string]string, nouceHeaderKey string) *httptest.ResponseRecorder {
 	path := "/hmac"
 
 	req, err := http.NewRequest("GET", path, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	for k, v := range reqHeaders {
+		req.Header.Set(k, v)
+	}
 
-	hmacHeaderKey := "HMAC-Authenticate-Hash"
-	secretInBytes := []byte("ThisIsSecret")
-	secretInBase64 := base64.StdEncoding.EncodeToString(secretInBytes)
-	message := []byte("this is http body content")
-	hmac := computeHMAC256(message, secretInBytes)
+	msg := []byte(bodyContent)
+	key := []byte(secretString)
 
-	hmacWrapper := NewHMACAuthenticator(hmacHeaderKey, secretInBase64)
+	hmacWrapper := HMACSHA1Signer(hmacHeaderKey, nouceHeaderKey, key)
 	router := httprouter.New()
 	grp := zin.NewGroup("/", hmacWrapper)
 	grp.R(router.GET, path, func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		w.Header().Set("Content-Language", "klingon")
-		w.Write(message)
+		w.Write(msg)
 	})
 
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestHMACSignature(t *testing.T) {
+	reqHeaders := map[string]string{}
+
+	rec := middlewareHMACTest(t, reqHeaders, "")
+
+	valueExpected := generateSignature([]byte(bodyContent), []byte(secretString))
 
 	// check if regular header value consistent or not
 	if rec.HeaderMap.Get("Content-Language") != "klingon" {
@@ -41,12 +59,39 @@ func TestHMACAuthenticator(t *testing.T) {
 	}
 
 	// check if "hmac" header value identical to the expected one
-	if rec.HeaderMap.Get(hmacHeaderKey) != hmac {
+	if rec.HeaderMap.Get(hmacHeaderKey) != valueExpected {
 		t.Fatalf("appended header inconsistent")
 	}
 
 	// check if response body consistent or not
-	if string(rec.Body.Bytes()) != string(message) {
+	if string(rec.Body.Bytes()) != bodyContent {
+		t.Fatalf("content body inconsistent")
+	}
+}
+
+func TestHMACSignatureWithNounce(t *testing.T) {
+	nouceInHex := hex.EncodeToString([]byte(nounceString))
+	reqHeaders := map[string]string{
+		nounceHeaderKey: nouceInHex,
+	}
+
+	rec := middlewareHMACTest(t, reqHeaders, nounceHeaderKey)
+
+	key := append([]byte(secretString), []byte(nounceString)...)
+	valueExpected := generateSignature([]byte(bodyContent), key)
+
+	// check if regular header value consistent or not
+	if rec.HeaderMap.Get("Content-Language") != "klingon" {
+		t.Fatalf("standard header inconsistent")
+	}
+
+	// check if "hmac" header value identical to the expected one
+	if rec.HeaderMap.Get(hmacHeaderKey) != valueExpected {
+		t.Fatalf("appended header inconsistent")
+	}
+
+	// check if response body consistent or not
+	if string(rec.Body.Bytes()) != bodyContent {
 		t.Fatalf("content body inconsistent")
 	}
 }


### PR DESCRIPTION
Add HMAC middleware in custom header.

usage:
```go
hmacHeaderKey := "HMAC-Signature-Content"
nounceHeaderKey := "" // use no nounce in this sample
secret := []byte("sample secret")

hmacWrapper := NewHMACAuthenticator(hmacHeaderKey, nounceHeaderKey, secret)
    grp := zin.NewGroup("/", hmacWrapper)
    grp.R(router.GET, "/path/to/add/hmac/header", someHandleFunc)
```